### PR TITLE
Use correct syntax for #elif directive

### DIFF
--- a/src/TridentTD_LineNotify.cpp
+++ b/src/TridentTD_LineNotify.cpp
@@ -33,7 +33,7 @@ SOFTWARE.
 
 #if defined(ESP8266)
 #define USER_AGENT     "ESP8266"
-#else if defined (ESP32)
+#elif defined (ESP32)
 #define USER_AGENT     "ESP32"
 #endif
 

--- a/src/TridentTD_LineNotify.h
+++ b/src/TridentTD_LineNotify.h
@@ -37,7 +37,7 @@ SOFTWARE.
 #include <Arduino.h>
 #if defined(ESP8266)
   #include <ESP8266WiFi.h>
-#else if defined (ESP32)
+#elif defined (ESP32)
   #include <WiFi.h>
   #include <WiFiClientSecure.h>
 #endif


### PR DESCRIPTION
The previous use of `#else if` results in warnings:
```
In file included from E:\electronics\arduino\libraries\TridentTD_LineNotify-2.1\src\TridentTD_LineNotify.cpp:32:0:

E:\electronics\arduino\libraries\TridentTD_LineNotify-2.1\src\TridentTD_LineNotify.h:40:7: warning: extra tokens at end of #else directive [-Wendif-labels]

 #else if defined (ESP32)

       ^

E:\electronics\arduino\libraries\TridentTD_LineNotify-2.1\src\TridentTD_LineNotify.cpp:36:7: warning: extra tokens at end of #else directive [-Wendif-labels]

 #else if defined (ESP32)

       ^
```
And also causes what was intended to be an `#elif` conditional to instead act as an `#else` conditional.