### PR TITLE
แก้ปัญหาใช้งานไม่ได้ใน ESP8266 core for Arduino เวอร์ชั่น V2.5.0 เป็นต้นไป

### DIFF
--- a/src/TridentTD_LineNotify.cpp
+++ b/src/TridentTD_LineNotify.cpp
@@ -82,7 +82,11 @@ bool TridentTD_LineNotify::_notify(String message, int StickerPackageID, int Sti
   if(WiFi.status() != WL_CONNECTED) return false;
   if(_token == "") return false;
   
+#if defined(ESP8266)
+  axTLS::WiFiClientSecure _clientSecure;
+#elif defined (ESP32)
   WiFiClientSecure _clientSecure;
+#endif
 
   if (!_clientSecure.connect("notify-api.line.me", 443)) {
     TD_DEBUG_PRINT("connection LINE failed");

--- a/src/TridentTD_LineNotify.h
+++ b/src/TridentTD_LineNotify.h
@@ -37,6 +37,7 @@ SOFTWARE.
 #include <Arduino.h>
 #if defined(ESP8266)
   #include <ESP8266WiFi.h>
+  #include <WiFiClientSecureAxTLS.h>
 #elif defined (ESP32)
   #include <WiFi.h>
   #include <WiFiClientSecure.h>


### PR DESCRIPTION
เกิดจากผู้พัฒนา ESP8266 core for Arduino เปลี่ยนไลบารี่จัดการ SSL/TLS ใหม่ แล้วใช้ไลบารี่ตัวใหม่เป็นค่าดีฟอล ส่งผลให้ไลบารี่นี้พัง ซึ่งได้แก้ปัญหาโดยกลับไปใช้ไลบารี่ของเก่า (axTLS)

ผมยังไม่ได้เทส เพราะไม่มีฮาร์ดแวร์นะครับ รบกวนเทสให้ด้วยนะครับ